### PR TITLE
Add dev script alias for tsdx watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "start": "tsdx watch",
+    "dev": "tsdx watch",
     "build": "tsdx build",
     "postbuild": "cp src/tokenlist.schema.json dist/tokenlist.schema.json",
     "test": "tsdx test",


### PR DESCRIPTION
Added 'dev' script as an alias for 'tsdx watch' in package.json to provide a more standardized development command name.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=vortex-nest&projectId=0e76605cb7f7499196e0adb35e709365)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0e76605cb7f7499196e0adb35e709365</projectId>-->